### PR TITLE
check user commands against valid commands

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,13 @@ const {hideBin} = require('yargs/helpers');
 const package_info = require('../package.json');
 const RyderSerial = require('ryderserial-proto');
 
+// import modules in each file found in src/cmds/ directory
+const normalize_path = require("path").join(__dirname, "cmds");
+// map through each command file and snag the `export.command` name to allow for modular list of valid commands (no hard-coding)
+const valid_commands = require("fs").readdirSync(normalize_path).map(cmd => require(`./cmds/${cmd}`).command.split(" ")[0]);
+
+// Continue application logic below
+
 const usage = `Ryder Prototype CLI ${package_info.version}.\n\nAll commands require the Ryder port to be set. You can do this by\neither specifying it with the option --ryder-port or by exporting\nthe environment variable RYDER_PORT.\n\nWarning: this is prototype software, never use your real seed phrases.\n\nUse --help to see a list of commands.`;
 
 yargs(hideBin(process.argv))
@@ -13,6 +20,11 @@ yargs(hideBin(process.argv))
 		{
 		if (!argv._.length)
 			return argv;
+		// if the given command is not valid, exit out
+		if (!(valid_commands.includes(argv._[0]))) {
+			console.log(`Invalid command: ${argv._[0]} is not a valid command.\nUse --help to see a list of commands.`);
+			process.exit(0);
+		}
 		if (!argv['ryder-port'] || argv['ryder-port'] === true)
 			{
 			if (process.env.RYDER_PORT)


### PR DESCRIPTION
# Description

This PR aims to resolve issue #2

## Problem

Currently, the CLI does not check input commands against valid commands. 

As a result, inputting a command that is not valid (such as `version` or `flamingo`) results in the following side effects:

- The connection that `RyderSerial` is handling ends up hanging; this hanging connection should be resolved with a call to `RyderSerial.prototype.close()` but is not
- The CLI user is required to input `^C` to kill the terminal process
- The CLI user does not receive any clear error message to illustrate that their command was not valid.

## Solution

- Dynamically load all valid command words from the command modules in `src/cmds/`
- Check the given command (from the user) against valid command words 
- If the input command is NOT valid: display an error message, exit the process
- If the input command IS valid; it should be executed (and the command file itself should handle a call to `RyderSerial.prototype.close()` if necessary)

