### PR TITLE
fix regex check for firmware version

### DIFF
--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -37,7 +37,7 @@ export default class Export extends RyderCommand {
         if (!this.ryder_serial) {
             return;
         }
-        let commands: number[] = [];
+        const commands: number[] = [];
         if (args.what === "identity") commands.push(RyderSerial.COMMAND_EXPORT_PUBLIC_IDENTITY);
         else {
             // TODO: RyderSerial.COMMAND_EXPORT_OWNER_APP_KEY_PRIVATE_KEY

--- a/src/commands/firmware.ts
+++ b/src/commands/firmware.ts
@@ -70,8 +70,8 @@ export default class Firmware extends RyderCommand {
         const { args, flags } = this.parse(Firmware);
 
         if (
-            args.action === "install" ||
-            (args.action === "download" && /^[0-9]+\.[0-9]+\.[0-9]+$/.test(args.ver))
+            (args.action === "install" || args.action === "download") &&
+            !/^[0-9]+\.[0-9]+\.[0-9]+$/.test(args.ver)
         ) {
             this.error(new Error("Version should be in the format X.Y.Z"), { exit: 1 });
         }


### PR DESCRIPTION
### Description

running `ryder-cli-proto firmware download 0.0.1 -R /dev/ttys004` threw `"Version should be in the format X.Y.Z"` error due to a missing not-operator `!` in `if` statement.

- [x] fix regex check for firmware version