### PR TITLE
Transaction support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+scraps.txt
 
 # Logs
 logs

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ $ npm install -g @lightlabs/ryder-cli-proto
 $ ryder-cli-proto COMMAND
 running command...
 $ ryder-cli-proto (-v|--version|version)
-@lightlabs/ryder-cli-proto/0.0.4 darwin-x64 node-v16.0.0
+@lightlabs/ryder-cli-proto/0.0.4 darwin-arm64 node-v15.3.0
 $ ryder-cli-proto --help [COMMAND]
 USAGE
   $ ryder-cli-proto COMMAND
@@ -59,6 +59,7 @@ USAGE
 * [`ryder-cli-proto help [COMMAND]`](#ryder-cli-proto-help-command)
 * [`ryder-cli-proto info`](#ryder-cli-proto-info)
 * [`ryder-cli-proto restore`](#ryder-cli-proto-restore)
+* [`ryder-cli-proto send-stx`](#ryder-cli-proto-send-stx)
 * [`ryder-cli-proto setup`](#ryder-cli-proto-setup)
 * [`ryder-cli-proto wake`](#ryder-cli-proto-wake)
 
@@ -149,13 +150,6 @@ OPTIONS
   -D, --debug
   -R, --ryder_port=ryder_port  (required) port of ryder device to connect to
   -h, --help                   show CLI help
-
-EXAMPLES
-  $ ryder-cli-proto info -R "/dev/ttys003"
-  hello world from ./src/hello.ts!
-
-  $ ryder-cli-proto info --ryder-port "/dev/ttys003"
-  Initialised Ryder FW version 0.0.2 on /dev/ttys003
 ```
 
 _See code: [src/commands/info.ts](https://github.com/Light-Labs/ryder-cli-proto/blob/v0.0.4/src/commands/info.ts)_
@@ -177,6 +171,26 @@ OPTIONS
 ```
 
 _See code: [src/commands/restore.ts](https://github.com/Light-Labs/ryder-cli-proto/blob/v0.0.4/src/commands/restore.ts)_
+
+## `ryder-cli-proto send-stx`
+
+Send STX a specified principal.
+
+```
+USAGE
+  $ ryder-cli-proto send-stx
+
+OPTIONS
+  -D, --debug
+  -R, --ryder_port=ryder_port          (required) port of ryder device to connect to
+  -h, --help                           show CLI help
+  --account=account                    (required) The account number to send from
+  --amount=amount                      (required) The amount in mSTX
+  --network=(mainnet|testnet|mocknet)  (required)
+  --recipient=recipient                (required) The principal to transfer the STX to
+```
+
+_See code: [src/commands/send-stx.ts](https://github.com/Light-Labs/ryder-cli-proto/blob/v0.0.4/src/commands/send-stx.ts)_
 
 ## `ryder-cli-proto setup`
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,11 @@
 {
-    "name": "ryder-cli-proto",
+    "name": "@lightlabs/ryder-cli-proto",
     "version": "0.0.4",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
+            "name": "@lightlabs/ryder-cli-proto",
             "version": "0.0.4",
             "license": "ISC",
             "dependencies": {
@@ -12,6 +13,8 @@
                 "@oclif/config": "^1.17.0",
                 "@oclif/plugin-help": "^3.2.2",
                 "@oclif/test": "^1.2.8",
+                "@stacks/network": "^1.2.2",
+                "@stacks/transactions": "^3.0.0-beta.0",
                 "@types/clear": "^0.1.1",
                 "@types/figlet": "^1.5.1",
                 "@types/inquirer": "^7.3.1",
@@ -21,7 +24,7 @@
                 "figlet": "^1.5.0",
                 "inquirer": "^8.1.0",
                 "node-fetch": "^2.6.1",
-                "ryderserial-proto": "^0.0.2",
+                "ryderserial-proto": "../ryderserial-proto",
                 "tslib": "^1.14.1"
             },
             "bin": {
@@ -46,6 +49,33 @@
             "engines": {
                 "node": ">=8.0.0"
             }
+        },
+        "../ryderserial-proto": {
+            "name": "@lightlabs/ryderserial-proto",
+            "version": "0.0.4",
+            "license": "ISC",
+            "dependencies": {
+                "@types/node": "^15.3.0",
+                "@types/serialport": "^8.0.1",
+                "serialport": "^9.0.6"
+            },
+            "devDependencies": {
+                "@tsconfig/recommended": "^1.0.1",
+                "@typescript-eslint/eslint-plugin": "^4.24.0",
+                "@typescript-eslint/parser": "^4.24.0",
+                "eslint": "^7.27.0",
+                "prettier": "2.3.0",
+                "typescript": "^4.2.4"
+            }
+        },
+        "../ryderserial-proto/dist": {
+            "extraneous": true
+        },
+        "../ryderserial-proto/dist/index": {
+            "extraneous": true
+        },
+        "../ryderserial-proto/dist/index.js": {
+            "extraneous": true
         },
         "node_modules/@babel/code-frame": {
             "version": "7.12.11",
@@ -817,149 +847,6 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/@serialport/binding-abstract": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.7.tgz",
-            "integrity": "sha512-g1ncCMIG9rMsxo/28ObYmXZcHThlvtZygsCANmyMUuFS7SwXY4+PhcEnt2+ZcMkEDNRiOklT+ngtIVx5GGpt/A==",
-            "dependencies": {
-                "debug": "^4.3.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/serialport/donate"
-            }
-        },
-        "node_modules/@serialport/binding-mock": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.0.7.tgz",
-            "integrity": "sha512-aR8H+htZwwZZkVb1MdbnNvGWw8eXVRqQ2qPhkbKyx0N/LY5aVIgCgT98Kt1YylLsG7SzNG+Jbhd4wzwEuPVT5Q==",
-            "dependencies": {
-                "@serialport/binding-abstract": "^9.0.7",
-                "debug": "^4.3.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/serialport/donate"
-            }
-        },
-        "node_modules/@serialport/bindings": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.1.0.tgz",
-            "integrity": "sha512-X0GM5iZgrBkR1HwoSDsJ/AJ+M61end5Ttg5mqcaUkwGCKpgJSDW3STX6pvFNr9xNzvqS56yuhAcU/eNJ2xuDaA==",
-            "hasInstallScript": true,
-            "dependencies": {
-                "@serialport/binding-abstract": "^9.0.7",
-                "@serialport/parser-readline": "^9.0.7",
-                "bindings": "^1.5.0",
-                "debug": "^4.3.1",
-                "nan": "^2.14.2",
-                "prebuild-install": "^6.0.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/serialport/donate"
-            }
-        },
-        "node_modules/@serialport/parser-byte-length": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-9.0.7.tgz",
-            "integrity": "sha512-evf7oOOSBMBn2AZZbgBFMRIyEzlsyQkhqaPm7IBCPTxMDXRf4tKkFYJHYZB0/6d1W4eI0meH079UqmSsh/uoDA==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/serialport/donate"
-            }
-        },
-        "node_modules/@serialport/parser-cctalk": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-9.0.7.tgz",
-            "integrity": "sha512-ert5jhMkeiTfr44TkbdySC09J8UwAsf/RxBucVN5Mz5enG509RggnkfFi4mfj3UCG2vZ7qsmM6gtZ62DshY02Q==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/serialport/donate"
-            }
-        },
-        "node_modules/@serialport/parser-delimiter": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.7.tgz",
-            "integrity": "sha512-Vb2NPeXPZ/28M4m5x4OAHFd8jRAeddNCgvL+Q+H/hqFPY1w47JcMLchC7pigRW8Cnt1fklmzfwdNQ8Fb+kMkxQ==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/serialport/donate"
-            }
-        },
-        "node_modules/@serialport/parser-inter-byte-timeout": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.0.7.tgz",
-            "integrity": "sha512-lUZ3cwgUluBvJ1jf+0LQsqoiPYAokDO6+fRCw9HCfnrF/OS60Gm4rxuyo2uQIueqZkJ7NIFP+ibKsULrA47AEA==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/serialport/donate"
-            }
-        },
-        "node_modules/@serialport/parser-readline": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.7.tgz",
-            "integrity": "sha512-ydoLbgVQQPxWrwbe3Fhh4XnZexbkEQAC6M/qgRTzjnKvTjrD61CJNxLc3vyDaAPI9bJIhTiI7eTX3JB5jJv8Hg==",
-            "dependencies": {
-                "@serialport/parser-delimiter": "^9.0.7"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/serialport/donate"
-            }
-        },
-        "node_modules/@serialport/parser-ready": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-9.0.7.tgz",
-            "integrity": "sha512-3qYhI4cNUPAYqVYvdwV57Y+PVRl4dJf1fPBtMoWtwDgwopsAXTR93WCs49WuUq9JCyNW+8Hrfqv8x8eNAD5Dqg==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/serialport/donate"
-            }
-        },
-        "node_modules/@serialport/parser-regex": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-9.0.7.tgz",
-            "integrity": "sha512-5XF+FXbhqQ/5bVKM4NaGs1m+E9KjfmeCx/obwsKaUZognQF67jwoTfjJJWNP/21jKfxdl8XoCYjZjASl3XKRAw==",
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/serialport/donate"
-            }
-        },
-        "node_modules/@serialport/stream": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.7.tgz",
-            "integrity": "sha512-c/h7HPAeFiryD9iTGlaSvPqHFHSZ0NMQHxC4rcmKS2Vu3qJuEtkBdTLABwsMp7iWEiSnI4KC3s7bHapaXP06FQ==",
-            "dependencies": {
-                "debug": "^4.3.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/serialport/donate"
-            }
-        },
         "node_modules/@sinonjs/commons": {
             "version": "1.8.3",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -976,6 +863,102 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
+        "node_modules/@stacks/common": {
+            "version": "3.0.0-beta.0",
+            "resolved": "https://registry.npmjs.org/@stacks/common/-/common-3.0.0-beta.0.tgz",
+            "integrity": "sha512-IwwQXOebhScL5B5bDSO2Pf4UunO+KdOjQdvofoMP6scz2D+kVf5Ie0CBoNdYDHQPqWAU20654Oa7dXUaldJ/GQ==",
+            "dependencies": {
+                "@types/node": "^14.14.43",
+                "bn.js": "^5.2.0",
+                "buffer": "^6.0.3",
+                "cross-fetch": "^3.1.4"
+            }
+        },
+        "node_modules/@stacks/common/node_modules/@types/node": {
+            "version": "14.17.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
+            "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ=="
+        },
+        "node_modules/@stacks/common/node_modules/bn.js": {
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+            "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+        },
+        "node_modules/@stacks/common/node_modules/buffer": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+            "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/feross"
+                },
+                {
+                    "type": "patreon",
+                    "url": "https://www.patreon.com/feross"
+                },
+                {
+                    "type": "consulting",
+                    "url": "https://feross.org/support"
+                }
+            ],
+            "dependencies": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.2.1"
+            }
+        },
+        "node_modules/@stacks/network": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@stacks/network/-/network-1.2.2.tgz",
+            "integrity": "sha512-xcWwuRrLJn9qqi3PEBcP2UPZHQztTZd31C0aVlzYHttNMir/sY9SrUqSnw45z2Jo4O9pIYYPIiPRtdV91Ho3fw==",
+            "dependencies": {
+                "@stacks/common": "^1.2.2"
+            }
+        },
+        "node_modules/@stacks/network/node_modules/@stacks/common": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@stacks/common/-/common-1.2.2.tgz",
+            "integrity": "sha512-knCqq88EBRCN8AhS7+Sx2PJuRv0EFNChEpqLqCAchCHCQfp5bWad/47Zw+fLP9ccBwFXh4pl1wDtbQLBfDo0+A==",
+            "dependencies": {
+                "cross-fetch": "^3.0.6"
+            }
+        },
+        "node_modules/@stacks/transactions": {
+            "version": "3.0.0-beta.0",
+            "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-3.0.0-beta.0.tgz",
+            "integrity": "sha512-Yy1G3SHQ5HG6GqGdi/+E1e0/oTjxdgprlalxTMQmDrcDTQXSraE9j9xO8P5pQPZiCaz1GKcw0Y1HTQG/w1F/Jw==",
+            "dependencies": {
+                "@stacks/common": "^3.0.0-beta.0",
+                "@stacks/network": "^1.2.2",
+                "@types/bn.js": "^4.11.6",
+                "@types/elliptic": "^6.4.12",
+                "@types/node": "^14.14.43",
+                "@types/randombytes": "^2.0.0",
+                "@types/sha.js": "^2.4.0",
+                "bn.js": "^4.12.0",
+                "c32check": "^1.1.2",
+                "cross-fetch": "^3.1.4",
+                "elliptic": "^6.5.4",
+                "lodash": "^4.17.20",
+                "randombytes": "^2.1.0",
+                "ripemd160-min": "^0.0.6",
+                "sha.js": "^2.4.11",
+                "smart-buffer": "^4.1.0"
+            }
+        },
+        "node_modules/@stacks/transactions/node_modules/@types/node": {
+            "version": "14.17.6",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
+            "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ=="
+        },
+        "node_modules/@types/bn.js": {
+            "version": "4.11.6",
+            "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+            "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/chai": {
             "version": "4.2.18",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.18.tgz",
@@ -985,6 +968,14 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@types/clear/-/clear-0.1.1.tgz",
             "integrity": "sha512-Wu6DxCnSjFiqymbTeyb63VdU1oKYW0qCnmOSBjpMyuvcuvI9keXfS6RbEcKYqUY0dPOLa34qV+XHAdgiRzPBtg=="
+        },
+        "node_modules/@types/elliptic": {
+            "version": "6.4.13",
+            "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.13.tgz",
+            "integrity": "sha512-e8iyLJ8vMLpWxXpVWrIt0ujqsfHWgVe5XAz9IMhBYoDirK6th7J+mHjzp797OLc62ZX419nrlwwzsNAA0a0mKg==",
+            "dependencies": {
+                "@types/bn.js": "*"
+            }
         },
         "node_modules/@types/expect": {
             "version": "24.3.0",
@@ -1072,10 +1063,18 @@
                 "form-data": "^3.0.0"
             }
         },
-        "node_modules/@types/serialport": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/@types/serialport/-/serialport-8.0.1.tgz",
-            "integrity": "sha512-IcKHq6b/ynKSF/x4al/Ce8+a0hpbYIEaIcK9Z3l4koLvQqAPSODZ37/hgemQx8dTu7fPZDMHN4bKmu89B3UaGA==",
+        "node_modules/@types/randombytes": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/randombytes/-/randombytes-2.0.0.tgz",
+            "integrity": "sha512-bz8PhAVlwN72vqefzxa14DKNT8jK/mV66CSjwdVQM/k3Th3EPKfUtdMniwZgMedQTFuywAsfjnZsg+pEnltaMA==",
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
+        "node_modules/@types/sha.js": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@types/sha.js/-/sha.js-2.4.0.tgz",
+            "integrity": "sha512-amxKgPy6WJTKuw8mpUwjX2BSxuBtBmZfRwIUDIuPJKNwGN8CWDli8JTg5ONTWOtcTkHIstvT7oAhhYXqEjStHQ==",
             "dependencies": {
                 "@types/node": "*"
             }
@@ -1417,47 +1416,11 @@
                 "node": ">=8"
             }
         },
-        "node_modules/aproba": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-        },
         "node_modules/archy": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
             "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
             "dev": true
-        },
-        "node_modules/are-we-there-yet": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-            "dependencies": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-            }
-        },
-        "node_modules/are-we-there-yet/node_modules/readable-stream": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-            "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-            "dependencies": {
-                "core-util-is": "~1.0.0",
-                "inherits": "~2.0.3",
-                "isarray": "~1.0.0",
-                "process-nextick-args": "~2.0.0",
-                "safe-buffer": "~5.1.1",
-                "string_decoder": "~1.1.1",
-                "util-deprecate": "~1.0.1"
-            }
-        },
-        "node_modules/are-we-there-yet/node_modules/string_decoder": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-            "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-            "dependencies": {
-                "safe-buffer": "~5.1.0"
-            }
         },
         "node_modules/argparse": {
             "version": "1.0.10",
@@ -1514,6 +1477,14 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "node_modules/base-x": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+            "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+            "dependencies": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1542,14 +1513,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "dependencies": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
         "node_modules/bl": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -1559,6 +1522,11 @@
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
             }
+        },
+        "node_modules/bn.js": {
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "node_modules/brace-expansion": {
             "version": "1.1.11",
@@ -1580,6 +1548,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
         "node_modules/browser-stdout": {
             "version": "1.3.1",
@@ -1638,6 +1611,19 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
+        },
+        "node_modules/c32check": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/c32check/-/c32check-1.1.2.tgz",
+            "integrity": "sha512-YgmbvOQ9HfoH7ptW80JP6WJdgoHJFGqFjxaFYvwD+bU5i3dJ44a1LI0yxdiA2n/tVKq9W92tYcFjTP5hGlvhcg==",
+            "dependencies": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.6.0",
+                "cross-sha256": "^1.1.2"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/caching-transform": {
             "version": "4.0.0",
@@ -1747,11 +1733,6 @@
                 "fsevents": "~2.3.1"
             }
         },
-        "node_modules/chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-        },
         "node_modules/clean-stack": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
@@ -1834,14 +1815,6 @@
                 "node": ">=0.8"
             }
         },
-        "node_modules/code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -1884,11 +1857,6 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
-        "node_modules/console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-        },
         "node_modules/convert-source-map": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -1898,10 +1866,27 @@
                 "safe-buffer": "~5.1.1"
             }
         },
-        "node_modules/core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        "node_modules/cross-fetch": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+            "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+            "dependencies": {
+                "node-fetch": "2.6.1"
+            }
+        },
+        "node_modules/cross-sha256": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cross-sha256/-/cross-sha256-1.1.2.tgz",
+            "integrity": "sha512-ZMGqJvPZQY/hmFvTJyM4LGVZIvEqD58GrCWA28goaDdo6wGzjgxWKEDxVfahkNCF/ryxBNfHe3Ql/BMSwPPbcg==",
+            "dependencies": {
+                "@types/node": "^8.0.0",
+                "buffer": "^5.6.0"
+            }
+        },
+        "node_modules/cross-sha256/node_modules/@types/node": {
+            "version": "8.10.66",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+            "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
         },
         "node_modules/cross-spawn": {
             "version": "7.0.3",
@@ -1942,17 +1927,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/decompress-response": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-            "dependencies": {
-                "mimic-response": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/deep-eql": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -1963,14 +1937,6 @@
             },
             "engines": {
                 "node": ">=0.12"
-            }
-        },
-        "node_modules/deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-            "engines": {
-                "node": ">=4.0.0"
             }
         },
         "node_modules/deep-is": {
@@ -2005,22 +1971,6 @@
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
             "engines": {
                 "node": ">=0.4.0"
-            }
-        },
-        "node_modules/delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
-        "node_modules/detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-            "bin": {
-                "detect-libc": "bin/detect-libc.js"
-            },
-            "engines": {
-                "node": ">=0.10"
             }
         },
         "node_modules/diff": {
@@ -2070,18 +2020,24 @@
             "integrity": "sha512-K2wXfo9iZQzNJNx67+Pld0DRF+9bYinj62gXCdgPhcu1vidwVuLPHQPPFnCdO55njWigXXpfBiT90jGUPbw8Zg==",
             "dev": true
         },
+        "node_modules/elliptic": {
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "dependencies": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
         "node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "node_modules/end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "dependencies": {
-                "once": "^1.4.0"
-            }
         },
         "node_modules/enquirer": {
             "version": "2.3.6",
@@ -2416,14 +2372,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/expand-template": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/expect": {
             "version": "27.0.2",
             "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.2.tgz",
@@ -2560,11 +2508,6 @@
                 "node": "^10.12.0 || >=12.0.0"
             }
         },
-        "node_modules/file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-        },
         "node_modules/fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -2683,11 +2626,6 @@
                 }
             ]
         },
-        "node_modules/fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-        },
         "node_modules/fs-extra": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -2727,64 +2665,6 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
-        "node_modules/gauge": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "dependencies": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            }
-        },
-        "node_modules/gauge/node_modules/ansi-regex": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gauge/node_modules/is-fullwidth-code-point": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-            "dependencies": {
-                "number-is-nan": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gauge/node_modules/string-width": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-            "dependencies": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/gauge/node_modules/strip-ansi": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-            "dependencies": {
-                "ansi-regex": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -2820,11 +2700,6 @@
             "engines": {
                 "node": ">=8.0.0"
             }
-        },
-        "node_modules/github-from-package": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
         },
         "node_modules/glob": {
             "version": "7.1.6",
@@ -2921,10 +2796,14 @@
                 "node": ">=4"
             }
         },
-        "node_modules/has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+        "node_modules/hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "dependencies": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
         },
         "node_modules/hasha": {
             "version": "5.2.2",
@@ -2958,6 +2837,16 @@
             "dev": true,
             "bin": {
                 "he": "bin/he"
+            }
+        },
+        "node_modules/hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "dependencies": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "node_modules/html-escaper": {
@@ -3052,11 +2941,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "node_modules/ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
         "node_modules/inquirer": {
             "version": "8.1.0",
@@ -3269,11 +3153,6 @@
             "engines": {
                 "node": ">=8"
             }
-        },
-        "node_modules/isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -4027,16 +3906,15 @@
                 "node": ">=6"
             }
         },
-        "node_modules/mimic-response": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-            "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-            "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
+        "node_modules/minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+        },
+        "node_modules/minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
         },
         "node_modules/minimatch": {
             "version": "3.0.4",
@@ -4053,7 +3931,8 @@
         "node_modules/minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
         },
         "node_modules/mkdirp": {
             "version": "0.5.5",
@@ -4066,11 +3945,6 @@
             "bin": {
                 "mkdirp": "bin/cmd.js"
             }
-        },
-        "node_modules/mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
         },
         "node_modules/mocha": {
             "version": "8.4.0",
@@ -4191,11 +4065,6 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
         },
-        "node_modules/nan": {
-            "version": "2.14.2",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
-        },
         "node_modules/nanoid": {
             "version": "3.1.20",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
@@ -4207,11 +4076,6 @@
             "engines": {
                 "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
             }
-        },
-        "node_modules/napi-build-utils": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
@@ -4231,22 +4095,6 @@
             },
             "engines": {
                 "node": ">= 10.13"
-            }
-        },
-        "node_modules/node-abi": {
-            "version": "2.30.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.0.tgz",
-            "integrity": "sha512-g6bZh3YCKQRdwuO/tSZZYJAw622SjsRfJ2X0Iy4sSOHZ34/sPPdVBn8fev2tj7njzLwuqPw9uMtGsGkO5kIQvg==",
-            "dependencies": {
-                "semver": "^5.4.1"
-            }
-        },
-        "node_modules/node-abi/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "bin": {
-                "semver": "bin/semver"
             }
         },
         "node_modules/node-fetch": {
@@ -4275,35 +4123,11 @@
             "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
             "dev": true
         },
-        "node_modules/noop-logger": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-            "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-        },
         "node_modules/normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
-        "node_modules/npmlog": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "dependencies": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-            }
-        },
-        "node_modules/number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -4509,18 +4333,11 @@
                 "node": ">=6"
             }
         },
-        "node_modules/object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "dependencies": {
                 "wrappy": "1"
             }
@@ -4862,33 +4679,6 @@
                 "node": ">=8"
             }
         },
-        "node_modules/prebuild-install": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.2.tgz",
-            "integrity": "sha512-PzYWIKZeP+967WuKYXlTOhYBgGOvTRSfaKI89XnfJ0ansRAH7hDU45X+K+FZeI1Wb/7p/NnuctPH3g0IqKUuSQ==",
-            "dependencies": {
-                "detect-libc": "^1.0.3",
-                "expand-template": "^2.0.3",
-                "github-from-package": "0.0.0",
-                "minimist": "^1.2.3",
-                "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^1.0.1",
-                "node-abi": "^2.21.0",
-                "noop-logger": "^0.1.1",
-                "npmlog": "^4.0.1",
-                "pump": "^3.0.0",
-                "rc": "^1.2.7",
-                "simple-get": "^3.0.3",
-                "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0"
-            },
-            "bin": {
-                "prebuild-install": "bin.js"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -4937,11 +4727,6 @@
                 "url": "https://github.com/chalk/ansi-styles?sponsor=1"
             }
         },
-        "node_modules/process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-        },
         "node_modules/process-on-spawn": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -4969,15 +4754,6 @@
             "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
             "engines": {
                 "node": ">= 8"
-            }
-        },
-        "node_modules/pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "dependencies": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
             }
         },
         "node_modules/punycode": {
@@ -5012,31 +4788,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
             "dependencies": {
                 "safe-buffer": "^5.1.0"
-            }
-        },
-        "node_modules/rc": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "dependencies": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "bin": {
-                "rc": "cli.js"
-            }
-        },
-        "node_modules/rc/node_modules/strip-json-comments": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/react-is": {
@@ -5163,6 +4916,14 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/ripemd160-min": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/ripemd160-min/-/ripemd160-min-0.0.6.tgz",
+            "integrity": "sha512-+GcJgQivhs6S9qvLogusiTcS9kQUfgR75whKuy5jIhuiOfQuJ8fjqxV6EGD5duH1Y/FawFUMtMhyeq3Fbnib8A==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/run-async": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -5205,14 +4966,8 @@
             }
         },
         "node_modules/ryderserial-proto": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/ryderserial-proto/-/ryderserial-proto-0.0.2.tgz",
-            "integrity": "sha512-I6SjBGqi3p6sk2xc0OUw5/YB2We6y3/8u3VqPj0xjEdydFhYBNgT7cNqZTScla9Oheuq7ENCjPVNqKX7GauUEA==",
-            "dependencies": {
-                "@types/node": "^15.3.0",
-                "@types/serialport": "^8.0.1",
-                "serialport": "^9.0.6"
-            }
+            "resolved": "../ryderserial-proto",
+            "link": true
         },
         "node_modules/safe-buffer": {
             "version": "5.1.2",
@@ -5247,34 +5002,23 @@
                 "randombytes": "^2.1.0"
             }
         },
-        "node_modules/serialport": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/serialport/-/serialport-9.1.0.tgz",
-            "integrity": "sha512-W17ji2TOotufIUCXIWcB6P+RztO1S4BcWsAc99jQn5BaH3Kw6xUyOX2ng0ZQ+hPjS/WWI2CdWynf4bKRJKD/+A==",
-            "dependencies": {
-                "@serialport/binding-mock": "^9.0.7",
-                "@serialport/bindings": "^9.1.0",
-                "@serialport/parser-byte-length": "^9.0.7",
-                "@serialport/parser-cctalk": "^9.0.7",
-                "@serialport/parser-delimiter": "^9.0.7",
-                "@serialport/parser-inter-byte-timeout": "^9.0.7",
-                "@serialport/parser-readline": "^9.0.7",
-                "@serialport/parser-ready": "^9.0.7",
-                "@serialport/parser-regex": "^9.0.7",
-                "@serialport/stream": "^9.0.7",
-                "debug": "^4.3.1"
-            },
-            "engines": {
-                "node": ">=10.0.0"
-            },
-            "funding": {
-                "url": "https://opencollective.com/serialport/donate"
-            }
-        },
         "node_modules/set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "node_modules/sha.js": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "dependencies": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            },
+            "bin": {
+                "sha.js": "bin.js"
+            }
         },
         "node_modules/shebang-command": {
             "version": "2.0.0",
@@ -5301,35 +5045,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-        },
-        "node_modules/simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/feross"
-                },
-                {
-                    "type": "patreon",
-                    "url": "https://www.patreon.com/feross"
-                },
-                {
-                    "type": "consulting",
-                    "url": "https://feross.org/support"
-                }
-            ]
-        },
-        "node_modules/simple-get": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-            "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-            "dependencies": {
-                "decompress-response": "^4.2.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
-            }
         },
         "node_modules/slash": {
             "version": "3.0.0",
@@ -5388,6 +5103,15 @@
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true
+        },
+        "node_modules/smart-buffer": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+            "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+            "engines": {
+                "node": ">= 6.0.0",
+                "npm": ">= 3.0.0"
+            }
         },
         "node_modules/source-map": {
             "version": "0.5.7",
@@ -5595,32 +5319,6 @@
             "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true
         },
-        "node_modules/tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "dependencies": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "node_modules/tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "dependencies": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -5785,17 +5483,6 @@
                 "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
             }
         },
-        "node_modules/tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "dependencies": {
-                "safe-buffer": "^5.0.1"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -5921,6 +5608,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "dev": true,
             "dependencies": {
                 "string-width": "^1.0.2 || 2"
             }
@@ -5929,6 +5617,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
             "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5937,6 +5626,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
             "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true,
             "engines": {
                 "node": ">=4"
             }
@@ -5945,6 +5635,7 @@
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
             "dependencies": {
                 "is-fullwidth-code-point": "^2.0.0",
                 "strip-ansi": "^4.0.0"
@@ -5957,6 +5648,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "dev": true,
             "dependencies": {
                 "ansi-regex": "^3.0.0"
             },
@@ -6039,7 +5731,8 @@
         "node_modules/wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "node_modules/write-file-atomic": {
             "version": "3.0.3",
@@ -6630,6 +6323,7 @@
             "resolved": "https://registry.npmjs.org/@oclif/command/-/command-1.8.0.tgz",
             "integrity": "sha512-5vwpq6kbvwkQwKqAoOU3L72GZ3Ta8RRrewKj9OJRolx28KLJJ8Dg9Rf7obRwt5jQA9bkYd8gqzMTrI7H3xLfaw==",
             "requires": {
+                "@oclif/config": "^1.15.1",
                 "@oclif/errors": "^1.3.3",
                 "@oclif/parser": "^3.8.3",
                 "@oclif/plugin-help": "^3",
@@ -6796,82 +6490,6 @@
                 "fancy-test": "^1.4.3"
             }
         },
-        "@serialport/binding-abstract": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/binding-abstract/-/binding-abstract-9.0.7.tgz",
-            "integrity": "sha512-g1ncCMIG9rMsxo/28ObYmXZcHThlvtZygsCANmyMUuFS7SwXY4+PhcEnt2+ZcMkEDNRiOklT+ngtIVx5GGpt/A==",
-            "requires": {
-                "debug": "^4.3.1"
-            }
-        },
-        "@serialport/binding-mock": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/binding-mock/-/binding-mock-9.0.7.tgz",
-            "integrity": "sha512-aR8H+htZwwZZkVb1MdbnNvGWw8eXVRqQ2qPhkbKyx0N/LY5aVIgCgT98Kt1YylLsG7SzNG+Jbhd4wzwEuPVT5Q==",
-            "requires": {
-                "@serialport/binding-abstract": "^9.0.7",
-                "debug": "^4.3.1"
-            }
-        },
-        "@serialport/bindings": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/@serialport/bindings/-/bindings-9.1.0.tgz",
-            "integrity": "sha512-X0GM5iZgrBkR1HwoSDsJ/AJ+M61end5Ttg5mqcaUkwGCKpgJSDW3STX6pvFNr9xNzvqS56yuhAcU/eNJ2xuDaA==",
-            "requires": {
-                "@serialport/binding-abstract": "^9.0.7",
-                "@serialport/parser-readline": "^9.0.7",
-                "bindings": "^1.5.0",
-                "debug": "^4.3.1",
-                "nan": "^2.14.2",
-                "prebuild-install": "^6.0.1"
-            }
-        },
-        "@serialport/parser-byte-length": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-byte-length/-/parser-byte-length-9.0.7.tgz",
-            "integrity": "sha512-evf7oOOSBMBn2AZZbgBFMRIyEzlsyQkhqaPm7IBCPTxMDXRf4tKkFYJHYZB0/6d1W4eI0meH079UqmSsh/uoDA=="
-        },
-        "@serialport/parser-cctalk": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-cctalk/-/parser-cctalk-9.0.7.tgz",
-            "integrity": "sha512-ert5jhMkeiTfr44TkbdySC09J8UwAsf/RxBucVN5Mz5enG509RggnkfFi4mfj3UCG2vZ7qsmM6gtZ62DshY02Q=="
-        },
-        "@serialport/parser-delimiter": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-delimiter/-/parser-delimiter-9.0.7.tgz",
-            "integrity": "sha512-Vb2NPeXPZ/28M4m5x4OAHFd8jRAeddNCgvL+Q+H/hqFPY1w47JcMLchC7pigRW8Cnt1fklmzfwdNQ8Fb+kMkxQ=="
-        },
-        "@serialport/parser-inter-byte-timeout": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-inter-byte-timeout/-/parser-inter-byte-timeout-9.0.7.tgz",
-            "integrity": "sha512-lUZ3cwgUluBvJ1jf+0LQsqoiPYAokDO6+fRCw9HCfnrF/OS60Gm4rxuyo2uQIueqZkJ7NIFP+ibKsULrA47AEA=="
-        },
-        "@serialport/parser-readline": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-readline/-/parser-readline-9.0.7.tgz",
-            "integrity": "sha512-ydoLbgVQQPxWrwbe3Fhh4XnZexbkEQAC6M/qgRTzjnKvTjrD61CJNxLc3vyDaAPI9bJIhTiI7eTX3JB5jJv8Hg==",
-            "requires": {
-                "@serialport/parser-delimiter": "^9.0.7"
-            }
-        },
-        "@serialport/parser-ready": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-ready/-/parser-ready-9.0.7.tgz",
-            "integrity": "sha512-3qYhI4cNUPAYqVYvdwV57Y+PVRl4dJf1fPBtMoWtwDgwopsAXTR93WCs49WuUq9JCyNW+8Hrfqv8x8eNAD5Dqg=="
-        },
-        "@serialport/parser-regex": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/parser-regex/-/parser-regex-9.0.7.tgz",
-            "integrity": "sha512-5XF+FXbhqQ/5bVKM4NaGs1m+E9KjfmeCx/obwsKaUZognQF67jwoTfjJJWNP/21jKfxdl8XoCYjZjASl3XKRAw=="
-        },
-        "@serialport/stream": {
-            "version": "9.0.7",
-            "resolved": "https://registry.npmjs.org/@serialport/stream/-/stream-9.0.7.tgz",
-            "integrity": "sha512-c/h7HPAeFiryD9iTGlaSvPqHFHSZ0NMQHxC4rcmKS2Vu3qJuEtkBdTLABwsMp7iWEiSnI4KC3s7bHapaXP06FQ==",
-            "requires": {
-                "debug": "^4.3.1"
-            }
-        },
         "@sinonjs/commons": {
             "version": "1.8.3",
             "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -6888,6 +6506,94 @@
                 "@sinonjs/commons": "^1.7.0"
             }
         },
+        "@stacks/common": {
+            "version": "3.0.0-beta.0",
+            "resolved": "https://registry.npmjs.org/@stacks/common/-/common-3.0.0-beta.0.tgz",
+            "integrity": "sha512-IwwQXOebhScL5B5bDSO2Pf4UunO+KdOjQdvofoMP6scz2D+kVf5Ie0CBoNdYDHQPqWAU20654Oa7dXUaldJ/GQ==",
+            "requires": {
+                "@types/node": "^14.14.43",
+                "bn.js": "^5.2.0",
+                "buffer": "^6.0.3",
+                "cross-fetch": "^3.1.4"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "14.17.6",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
+                    "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ=="
+                },
+                "bn.js": {
+                    "version": "5.2.0",
+                    "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
+                    "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
+                },
+                "buffer": {
+                    "version": "6.0.3",
+                    "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+                    "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+                    "requires": {
+                        "base64-js": "^1.3.1",
+                        "ieee754": "^1.2.1"
+                    }
+                }
+            }
+        },
+        "@stacks/network": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/@stacks/network/-/network-1.2.2.tgz",
+            "integrity": "sha512-xcWwuRrLJn9qqi3PEBcP2UPZHQztTZd31C0aVlzYHttNMir/sY9SrUqSnw45z2Jo4O9pIYYPIiPRtdV91Ho3fw==",
+            "requires": {
+                "@stacks/common": "^1.2.2"
+            },
+            "dependencies": {
+                "@stacks/common": {
+                    "version": "1.2.2",
+                    "resolved": "https://registry.npmjs.org/@stacks/common/-/common-1.2.2.tgz",
+                    "integrity": "sha512-knCqq88EBRCN8AhS7+Sx2PJuRv0EFNChEpqLqCAchCHCQfp5bWad/47Zw+fLP9ccBwFXh4pl1wDtbQLBfDo0+A==",
+                    "requires": {
+                        "cross-fetch": "^3.0.6"
+                    }
+                }
+            }
+        },
+        "@stacks/transactions": {
+            "version": "3.0.0-beta.0",
+            "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-3.0.0-beta.0.tgz",
+            "integrity": "sha512-Yy1G3SHQ5HG6GqGdi/+E1e0/oTjxdgprlalxTMQmDrcDTQXSraE9j9xO8P5pQPZiCaz1GKcw0Y1HTQG/w1F/Jw==",
+            "requires": {
+                "@stacks/common": "^3.0.0-beta.0",
+                "@stacks/network": "^1.2.2",
+                "@types/bn.js": "^4.11.6",
+                "@types/elliptic": "^6.4.12",
+                "@types/node": "^14.14.43",
+                "@types/randombytes": "^2.0.0",
+                "@types/sha.js": "^2.4.0",
+                "bn.js": "^4.12.0",
+                "c32check": "^1.1.2",
+                "cross-fetch": "^3.1.4",
+                "elliptic": "^6.5.4",
+                "lodash": "^4.17.20",
+                "randombytes": "^2.1.0",
+                "ripemd160-min": "^0.0.6",
+                "sha.js": "^2.4.11",
+                "smart-buffer": "^4.1.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "14.17.6",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.6.tgz",
+                    "integrity": "sha512-iBxsxU7eswQDGhlr3AiamBxOssaYxbM+NKXVil8jg9yFXvrfEFbDumLD/2dMTB+zYyg7w+Xjt8yuxfdbUHAtcQ=="
+                }
+            }
+        },
+        "@types/bn.js": {
+            "version": "4.11.6",
+            "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-4.11.6.tgz",
+            "integrity": "sha512-pqr857jrp2kPuO9uRjZ3PwnJTjoQy+fcdxvBTvHm6dkmEL9q+hDD/2j/0ELOBPtPnS8LjCX0gI9nbl8lVkadpg==",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
         "@types/chai": {
             "version": "4.2.18",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.18.tgz",
@@ -6897,6 +6603,14 @@
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@types/clear/-/clear-0.1.1.tgz",
             "integrity": "sha512-Wu6DxCnSjFiqymbTeyb63VdU1oKYW0qCnmOSBjpMyuvcuvI9keXfS6RbEcKYqUY0dPOLa34qV+XHAdgiRzPBtg=="
+        },
+        "@types/elliptic": {
+            "version": "6.4.13",
+            "resolved": "https://registry.npmjs.org/@types/elliptic/-/elliptic-6.4.13.tgz",
+            "integrity": "sha512-e8iyLJ8vMLpWxXpVWrIt0ujqsfHWgVe5XAz9IMhBYoDirK6th7J+mHjzp797OLc62ZX419nrlwwzsNAA0a0mKg==",
+            "requires": {
+                "@types/bn.js": "*"
+            }
         },
         "@types/expect": {
             "version": "24.3.0",
@@ -6983,10 +6697,18 @@
                 "form-data": "^3.0.0"
             }
         },
-        "@types/serialport": {
-            "version": "8.0.1",
-            "resolved": "https://registry.npmjs.org/@types/serialport/-/serialport-8.0.1.tgz",
-            "integrity": "sha512-IcKHq6b/ynKSF/x4al/Ce8+a0hpbYIEaIcK9Z3l4koLvQqAPSODZ37/hgemQx8dTu7fPZDMHN4bKmu89B3UaGA==",
+        "@types/randombytes": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/@types/randombytes/-/randombytes-2.0.0.tgz",
+            "integrity": "sha512-bz8PhAVlwN72vqefzxa14DKNT8jK/mV66CSjwdVQM/k3Th3EPKfUtdMniwZgMedQTFuywAsfjnZsg+pEnltaMA==",
+            "requires": {
+                "@types/node": "*"
+            }
+        },
+        "@types/sha.js": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/@types/sha.js/-/sha.js-2.4.0.tgz",
+            "integrity": "sha512-amxKgPy6WJTKuw8mpUwjX2BSxuBtBmZfRwIUDIuPJKNwGN8CWDli8JTg5ONTWOtcTkHIstvT7oAhhYXqEjStHQ==",
             "requires": {
                 "@types/node": "*"
             }
@@ -7213,49 +6935,11 @@
                 "default-require-extensions": "^3.0.0"
             }
         },
-        "aproba": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-            "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-        },
         "archy": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
             "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA=",
             "dev": true
-        },
-        "are-we-there-yet": {
-            "version": "1.1.5",
-            "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
-            "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-            "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^2.0.6"
-            },
-            "dependencies": {
-                "readable-stream": {
-                    "version": "2.3.7",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-                    "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-                    "requires": {
-                        "core-util-is": "~1.0.0",
-                        "inherits": "~2.0.3",
-                        "isarray": "~1.0.0",
-                        "process-nextick-args": "~2.0.0",
-                        "safe-buffer": "~5.1.1",
-                        "string_decoder": "~1.1.1",
-                        "util-deprecate": "~1.0.1"
-                    }
-                },
-                "string_decoder": {
-                    "version": "1.1.1",
-                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-                    "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-                    "requires": {
-                        "safe-buffer": "~5.1.0"
-                    }
-                }
-            }
         },
         "argparse": {
             "version": "1.0.10",
@@ -7300,6 +6984,14 @@
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
             "dev": true
         },
+        "base-x": {
+            "version": "3.0.8",
+            "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.8.tgz",
+            "integrity": "sha512-Rl/1AWP4J/zRrk54hhlxH4drNxPJXYUaKffODVI53/dAsV4t9fBxyxYKAVPU1XBHxYwOWP9h9H0hM2MVw4YfJA==",
+            "requires": {
+                "safe-buffer": "^5.0.1"
+            }
+        },
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -7311,14 +7003,6 @@
             "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
             "dev": true
         },
-        "bindings": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
-            "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-            "requires": {
-                "file-uri-to-path": "1.0.0"
-            }
-        },
         "bl": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
@@ -7328,6 +7012,11 @@
                 "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
             }
+        },
+        "bn.js": {
+            "version": "4.12.0",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+            "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
         },
         "brace-expansion": {
             "version": "1.1.11",
@@ -7346,6 +7035,11 @@
             "requires": {
                 "fill-range": "^7.0.1"
             }
+        },
+        "brorand": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+            "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
         },
         "browser-stdout": {
             "version": "1.3.1",
@@ -7380,6 +7074,16 @@
             "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
             "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
             "dev": true
+        },
+        "c32check": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/c32check/-/c32check-1.1.2.tgz",
+            "integrity": "sha512-YgmbvOQ9HfoH7ptW80JP6WJdgoHJFGqFjxaFYvwD+bU5i3dJ44a1LI0yxdiA2n/tVKq9W92tYcFjTP5hGlvhcg==",
+            "requires": {
+                "base-x": "^3.0.8",
+                "buffer": "^5.6.0",
+                "cross-sha256": "^1.1.2"
+            }
         },
         "caching-transform": {
             "version": "4.0.0",
@@ -7462,11 +7166,6 @@
                 "readdirp": "~3.5.0"
             }
         },
-        "chownr": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-            "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
-        },
         "clean-stack": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-3.0.1.tgz",
@@ -7521,11 +7220,6 @@
             "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
             "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         },
-        "code-point-at": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
-        },
         "color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -7565,11 +7259,6 @@
             "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
             "dev": true
         },
-        "console-control-strings": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-            "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
-        },
         "convert-source-map": {
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
@@ -7579,10 +7268,29 @@
                 "safe-buffer": "~5.1.1"
             }
         },
-        "core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+        "cross-fetch": {
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.4.tgz",
+            "integrity": "sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==",
+            "requires": {
+                "node-fetch": "2.6.1"
+            }
+        },
+        "cross-sha256": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/cross-sha256/-/cross-sha256-1.1.2.tgz",
+            "integrity": "sha512-ZMGqJvPZQY/hmFvTJyM4LGVZIvEqD58GrCWA28goaDdo6wGzjgxWKEDxVfahkNCF/ryxBNfHe3Ql/BMSwPPbcg==",
+            "requires": {
+                "@types/node": "^8.0.0",
+                "buffer": "^5.6.0"
+            },
+            "dependencies": {
+                "@types/node": {
+                    "version": "8.10.66",
+                    "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.66.tgz",
+                    "integrity": "sha512-tktOkFUA4kXx2hhhrB8bIFb5TbwzS4uOhKEmwiD+NoiL0qtP2OQ9mFldbgD4dV1djrlBYP6eBuQZiWjuHUpqFw=="
+                }
+            }
         },
         "cross-spawn": {
             "version": "7.0.3",
@@ -7609,14 +7317,6 @@
             "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
             "dev": true
         },
-        "decompress-response": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
-            "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-            "requires": {
-                "mimic-response": "^2.0.0"
-            }
-        },
         "deep-eql": {
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-3.0.1.tgz",
@@ -7625,11 +7325,6 @@
             "requires": {
                 "type-detect": "^4.0.0"
             }
-        },
-        "deep-extend": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-            "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "deep-is": {
             "version": "0.1.3",
@@ -7658,16 +7353,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-        },
-        "delegates": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-            "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
-        },
-        "detect-libc": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-            "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
         },
         "diff": {
             "version": "5.0.0",
@@ -7704,18 +7389,24 @@
             "integrity": "sha512-K2wXfo9iZQzNJNx67+Pld0DRF+9bYinj62gXCdgPhcu1vidwVuLPHQPPFnCdO55njWigXXpfBiT90jGUPbw8Zg==",
             "dev": true
         },
+        "elliptic": {
+            "version": "6.5.4",
+            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+            "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+            "requires": {
+                "bn.js": "^4.11.9",
+                "brorand": "^1.1.0",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.1",
+                "inherits": "^2.0.4",
+                "minimalistic-assert": "^1.0.1",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
+        },
         "emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
             "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
-        },
-        "end-of-stream": {
-            "version": "1.4.4",
-            "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
-            "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-            "requires": {
-                "once": "^1.4.0"
-            }
         },
         "enquirer": {
             "version": "2.3.6",
@@ -7960,11 +7651,6 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
-        "expand-template": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-            "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
-        },
         "expect": {
             "version": "27.0.2",
             "resolved": "https://registry.npmjs.org/expect/-/expect-27.0.2.tgz",
@@ -8073,11 +7759,6 @@
                 "flat-cache": "^3.0.4"
             }
         },
-        "file-uri-to-path": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-            "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
-        },
         "fill-range": {
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -8155,11 +7836,6 @@
             "integrity": "sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==",
             "dev": true
         },
-        "fs-constants": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
-        },
         "fs-extra": {
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
@@ -8189,54 +7865,6 @@
             "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
             "dev": true
         },
-        "gauge": {
-            "version": "2.7.4",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-            "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-            "requires": {
-                "aproba": "^1.0.3",
-                "console-control-strings": "^1.0.0",
-                "has-unicode": "^2.0.0",
-                "object-assign": "^4.1.0",
-                "signal-exit": "^3.0.0",
-                "string-width": "^1.0.1",
-                "strip-ansi": "^3.0.1",
-                "wide-align": "^1.1.0"
-            },
-            "dependencies": {
-                "ansi-regex": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-                    "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-                },
-                "is-fullwidth-code-point": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-                    "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-                    "requires": {
-                        "number-is-nan": "^1.0.0"
-                    }
-                },
-                "string-width": {
-                    "version": "1.0.2",
-                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-                    "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-                    "requires": {
-                        "code-point-at": "^1.0.0",
-                        "is-fullwidth-code-point": "^1.0.0",
-                        "strip-ansi": "^3.0.0"
-                    }
-                },
-                "strip-ansi": {
-                    "version": "3.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-                    "requires": {
-                        "ansi-regex": "^2.0.0"
-                    }
-                }
-            }
-        },
         "gensync": {
             "version": "1.0.0-beta.2",
             "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -8260,11 +7888,6 @@
             "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
             "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
             "dev": true
-        },
-        "github-from-package": {
-            "version": "0.0.0",
-            "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-            "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
         },
         "glob": {
             "version": "7.1.6",
@@ -8333,10 +7956,14 @@
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
             "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
-        "has-unicode": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-            "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+        "hash.js": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+            "requires": {
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.1"
+            }
         },
         "hasha": {
             "version": "5.2.2",
@@ -8361,6 +7988,16 @@
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
             "dev": true
+        },
+        "hmac-drbg": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+            "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+            "requires": {
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
+            }
         },
         "html-escaper": {
             "version": "2.0.2",
@@ -8422,11 +8059,6 @@
             "version": "2.0.4",
             "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
             "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        },
-        "ini": {
-            "version": "1.3.8",
-            "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
-            "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
         },
         "inquirer": {
             "version": "8.1.0",
@@ -8572,11 +8204,6 @@
             "requires": {
                 "is-docker": "^2.0.0"
             }
-        },
-        "isarray": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
             "version": "2.0.0",
@@ -9160,10 +8787,15 @@
             "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
             "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
         },
-        "mimic-response": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-            "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+        "minimalistic-assert": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+        },
+        "minimalistic-crypto-utils": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+            "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
         },
         "minimatch": {
             "version": "3.0.4",
@@ -9177,7 +8809,8 @@
         "minimist": {
             "version": "1.2.5",
             "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+            "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+            "dev": true
         },
         "mkdirp": {
             "version": "0.5.5",
@@ -9187,11 +8820,6 @@
             "requires": {
                 "minimist": "^1.2.5"
             }
-        },
-        "mkdirp-classic": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
-            "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
         },
         "mocha": {
             "version": "8.4.0",
@@ -9285,21 +8913,11 @@
             "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
             "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
         },
-        "nan": {
-            "version": "2.14.2",
-            "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
-            "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
-        },
         "nanoid": {
             "version": "3.1.20",
             "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.20.tgz",
             "integrity": "sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==",
             "dev": true
-        },
-        "napi-build-utils": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-            "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
         },
         "natural-compare": {
             "version": "1.4.0",
@@ -9316,21 +8934,6 @@
                 "json-stringify-safe": "^5.0.1",
                 "lodash.set": "^4.3.2",
                 "propagate": "^2.0.0"
-            }
-        },
-        "node-abi": {
-            "version": "2.30.0",
-            "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.30.0.tgz",
-            "integrity": "sha512-g6bZh3YCKQRdwuO/tSZZYJAw622SjsRfJ2X0Iy4sSOHZ34/sPPdVBn8fev2tj7njzLwuqPw9uMtGsGkO5kIQvg==",
-            "requires": {
-                "semver": "^5.4.1"
-            },
-            "dependencies": {
-                "semver": {
-                    "version": "5.7.1",
-                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-                    "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-                }
             }
         },
         "node-fetch": {
@@ -9353,32 +8956,11 @@
             "integrity": "sha512-LLUo+PpH3dU6XizX3iVoubUNheF/owjXCZZ5yACDxNnPtgFuludV1ZL3ayK1kVep42Rmm0+R9/Y60NQbZ2bifw==",
             "dev": true
         },
-        "noop-logger": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-            "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
-        },
         "normalize-path": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
             "dev": true
-        },
-        "npmlog": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-            "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-            "requires": {
-                "are-we-there-yet": "~1.1.2",
-                "console-control-strings": "~1.1.0",
-                "gauge": "~2.7.3",
-                "set-blocking": "~2.0.0"
-            }
-        },
-        "number-is-nan": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "nyc": {
             "version": "15.1.0",
@@ -9541,15 +9123,11 @@
                 }
             }
         },
-        "object-assign": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-        },
         "once": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
             "requires": {
                 "wrappy": "1"
             }
@@ -9787,27 +9365,6 @@
                 }
             }
         },
-        "prebuild-install": {
-            "version": "6.1.2",
-            "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.1.2.tgz",
-            "integrity": "sha512-PzYWIKZeP+967WuKYXlTOhYBgGOvTRSfaKI89XnfJ0ansRAH7hDU45X+K+FZeI1Wb/7p/NnuctPH3g0IqKUuSQ==",
-            "requires": {
-                "detect-libc": "^1.0.3",
-                "expand-template": "^2.0.3",
-                "github-from-package": "0.0.0",
-                "minimist": "^1.2.3",
-                "mkdirp-classic": "^0.5.3",
-                "napi-build-utils": "^1.0.1",
-                "node-abi": "^2.21.0",
-                "noop-logger": "^0.1.1",
-                "npmlog": "^4.0.1",
-                "pump": "^3.0.0",
-                "rc": "^1.2.7",
-                "simple-get": "^3.0.3",
-                "tar-fs": "^2.0.0",
-                "tunnel-agent": "^0.6.0"
-            }
-        },
         "prelude-ls": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -9840,11 +9397,6 @@
                 }
             }
         },
-        "process-nextick-args": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-            "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-        },
         "process-on-spawn": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/process-on-spawn/-/process-on-spawn-1.0.0.tgz",
@@ -9865,15 +9417,6 @@
             "resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
             "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag=="
         },
-        "pump": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-            "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-            "requires": {
-                "end-of-stream": "^1.1.0",
-                "once": "^1.3.1"
-            }
-        },
         "punycode": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -9889,27 +9432,8 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
             "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-            "dev": true,
             "requires": {
                 "safe-buffer": "^5.1.0"
-            }
-        },
-        "rc": {
-            "version": "1.2.8",
-            "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
-            "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-            "requires": {
-                "deep-extend": "^0.6.0",
-                "ini": "~1.3.0",
-                "minimist": "^1.2.0",
-                "strip-json-comments": "~2.0.1"
-            },
-            "dependencies": {
-                "strip-json-comments": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-                    "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
-                }
             }
         },
         "react-is": {
@@ -9999,6 +9523,11 @@
                 "glob": "^7.1.3"
             }
         },
+        "ripemd160-min": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/ripemd160-min/-/ripemd160-min-0.0.6.tgz",
+            "integrity": "sha512-+GcJgQivhs6S9qvLogusiTcS9kQUfgR75whKuy5jIhuiOfQuJ8fjqxV6EGD5duH1Y/FawFUMtMhyeq3Fbnib8A=="
+        },
         "run-async": {
             "version": "2.4.1",
             "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.4.1.tgz",
@@ -10021,13 +9550,17 @@
             }
         },
         "ryderserial-proto": {
-            "version": "0.0.2",
-            "resolved": "https://registry.npmjs.org/ryderserial-proto/-/ryderserial-proto-0.0.2.tgz",
-            "integrity": "sha512-I6SjBGqi3p6sk2xc0OUw5/YB2We6y3/8u3VqPj0xjEdydFhYBNgT7cNqZTScla9Oheuq7ENCjPVNqKX7GauUEA==",
+            "version": "file:../ryderserial-proto",
             "requires": {
+                "@tsconfig/recommended": "^1.0.1",
                 "@types/node": "^15.3.0",
                 "@types/serialport": "^8.0.1",
-                "serialport": "^9.0.6"
+                "@typescript-eslint/eslint-plugin": "^4.24.0",
+                "@typescript-eslint/parser": "^4.24.0",
+                "eslint": "^7.27.0",
+                "prettier": "2.3.0",
+                "serialport": "^9.0.6",
+                "typescript": "^4.2.4"
             }
         },
         "safe-buffer": {
@@ -10057,28 +9590,20 @@
                 "randombytes": "^2.1.0"
             }
         },
-        "serialport": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/serialport/-/serialport-9.1.0.tgz",
-            "integrity": "sha512-W17ji2TOotufIUCXIWcB6P+RztO1S4BcWsAc99jQn5BaH3Kw6xUyOX2ng0ZQ+hPjS/WWI2CdWynf4bKRJKD/+A==",
-            "requires": {
-                "@serialport/binding-mock": "^9.0.7",
-                "@serialport/bindings": "^9.1.0",
-                "@serialport/parser-byte-length": "^9.0.7",
-                "@serialport/parser-cctalk": "^9.0.7",
-                "@serialport/parser-delimiter": "^9.0.7",
-                "@serialport/parser-inter-byte-timeout": "^9.0.7",
-                "@serialport/parser-readline": "^9.0.7",
-                "@serialport/parser-ready": "^9.0.7",
-                "@serialport/parser-regex": "^9.0.7",
-                "@serialport/stream": "^9.0.7",
-                "debug": "^4.3.1"
-            }
-        },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+            "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+            "dev": true
+        },
+        "sha.js": {
+            "version": "2.4.11",
+            "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.11.tgz",
+            "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
+            "requires": {
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
+            }
         },
         "shebang-command": {
             "version": "2.0.0",
@@ -10099,21 +9624,6 @@
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
             "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
-        },
-        "simple-concat": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
-            "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
-        },
-        "simple-get": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
-            "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-            "requires": {
-                "decompress-response": "^4.2.0",
-                "once": "^1.3.1",
-                "simple-concat": "^1.0.0"
-            }
         },
         "slash": {
             "version": "3.0.0",
@@ -10156,6 +9666,11 @@
                     "dev": true
                 }
             }
+        },
+        "smart-buffer": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
+            "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
         },
         "source-map": {
             "version": "0.5.7",
@@ -10314,29 +9829,6 @@
                 }
             }
         },
-        "tar-fs": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
-            "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
-            "requires": {
-                "chownr": "^1.1.1",
-                "mkdirp-classic": "^0.5.2",
-                "pump": "^3.0.0",
-                "tar-stream": "^2.1.4"
-            }
-        },
-        "tar-stream": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
-            "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
-            "requires": {
-                "bl": "^4.0.3",
-                "end-of-stream": "^1.4.1",
-                "fs-constants": "^1.0.0",
-                "inherits": "^2.0.3",
-                "readable-stream": "^3.1.1"
-            }
-        },
         "test-exclude": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
@@ -10461,14 +9953,6 @@
                 "tslib": "^1.8.1"
             }
         },
-        "tunnel-agent": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-            "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-            "requires": {
-                "safe-buffer": "^5.0.1"
-            }
-        },
         "type-check": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -10562,6 +10046,7 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
             "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+            "dev": true,
             "requires": {
                 "string-width": "^1.0.2 || 2"
             },
@@ -10569,17 +10054,20 @@
                 "ansi-regex": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
                 },
                 "is-fullwidth-code-point": {
                     "version": "2.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
                 },
                 "string-width": {
                     "version": "2.1.1",
                     "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
                     "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+                    "dev": true,
                     "requires": {
                         "is-fullwidth-code-point": "^2.0.0",
                         "strip-ansi": "^4.0.0"
@@ -10589,6 +10077,7 @@
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
                     "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                    "dev": true,
                     "requires": {
                         "ansi-regex": "^3.0.0"
                     }
@@ -10651,7 +10140,8 @@
         "wrappy": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
         },
         "write-file-atomic": {
             "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
         "prettier": "prettier --write .",
         "lint": "prettier --check . && eslint . --ext .ts --quiet",
         "build": "tsc -p .",
+        "dev": "tsc --watch -p .",
         "local": "npm i -g . && ryder-cli-proto",
         "refresh": "rm -rf ./node_modules ./package-lock.json && npm install"
     },
@@ -51,6 +52,8 @@
         "@oclif/config": "^1.17.0",
         "@oclif/plugin-help": "^3.2.2",
         "@oclif/test": "^1.2.8",
+        "@stacks/network": "^1.2.2",
+        "@stacks/transactions": "^3.0.0-beta.0",
         "@types/clear": "^0.1.1",
         "@types/figlet": "^1.5.1",
         "@types/inquirer": "^7.3.1",
@@ -60,7 +63,8 @@
         "figlet": "^1.5.0",
         "inquirer": "^8.1.0",
         "node-fetch": "^2.6.1",
-        "ryderserial-proto": "^0.0.2",
+        
+        "ryderserial-proto": "../ryderserial-proto",
         "tslib": "^1.14.1"
     },
     "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -63,8 +63,7 @@
         "figlet": "^1.5.0",
         "inquirer": "^8.1.0",
         "node-fetch": "^2.6.1",
-        
-        "ryderserial-proto": "../ryderserial-proto",
+        "ryderserial-proto": "^0.0.5",
         "tslib": "^1.14.1"
     },
     "devDependencies": {

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -73,8 +73,9 @@ export default class Export extends RyderCommand {
             }
         }
         if (args.what === "identity" && typeof response === 'string') {
-            console.log(getAddressFromPublicKey(response, TransactionVersion.Mainnet));
-            console.log(getAddressFromPublicKey(response, TransactionVersion.Testnet));
+            const buff = Buffer.from(response, 'binary');
+            console.log(getAddressFromPublicKey(buff, TransactionVersion.Mainnet));
+            console.log(getAddressFromPublicKey(buff, TransactionVersion.Testnet));
         }
         this.ryder_serial.close();
     }

--- a/src/commands/export.ts
+++ b/src/commands/export.ts
@@ -1,6 +1,8 @@
 import { flags } from "@oclif/command";
 import RyderCommand from "../base";
 import RyderSerial from "ryderserial-proto";
+import { getAddressFromPublicKey } from "@stacks/transactions";
+import { TransactionVersion } from "@stacks/common";
 
 export default class Export extends RyderCommand {
     static description = "Export an identity or key from a Ryder";
@@ -59,7 +61,7 @@ export default class Export extends RyderCommand {
         commands.push(args.id_number);
         let response = await this.ryder_serial.send(commands);
         if (args.what !== "app_key") {
-            console.log(response);
+            console.log(typeof response === 'number' ? response : Buffer.from(response, 'binary').toString('hex'));
         } else if (response !== RyderSerial.RESPONSE_SEND_INPUT) {
             console.log(
                 "Ryder did not request user input, it might doing something else or it is stuck in the wrong mode."
@@ -67,8 +69,12 @@ export default class Export extends RyderCommand {
         } else {
             response = await this.ryder_serial.send(args.app_domain + "\0");
             if (response !== RyderSerial.RESPONSE_REJECTED) {
-                console.log(response);
+                console.log(typeof response === 'number' ? response : Buffer.from(response, 'binary').toString('hex'));
             }
+        }
+        if (args.what === "identity" && typeof response === 'string') {
+            console.log(getAddressFromPublicKey(response, TransactionVersion.Mainnet));
+            console.log(getAddressFromPublicKey(response, TransactionVersion.Testnet));
         }
         this.ryder_serial.close();
     }

--- a/src/commands/info.ts
+++ b/src/commands/info.ts
@@ -6,11 +6,6 @@ import chalk from "chalk";
 export default class Info extends RyderCommand {
     static description = "Read Ryder device information.";
 
-    static examples = [
-        `$ ryder-cli-proto info -R "/dev/ttys003"\nhello world from ./src/hello.ts!\n`,
-        `$ ryder-cli-proto info --ryder-port "/dev/ttys003"\nInitialised Ryder FW version 0.0.2 on /dev/ttys003`,
-    ];
-
     static flags = {
         ...RyderCommand.flags,
         help: flags.help({ char: "h" }),

--- a/src/commands/send-stx.ts
+++ b/src/commands/send-stx.ts
@@ -1,7 +1,7 @@
 import { flags } from "@oclif/command";
 import RyderSerial from "ryderserial-proto";
 import RyderCommand from "../base";
-import { principalFlag, networkFlag, networkFromString } from "../common";
+import { principalFlag, networkFlag, networkFromString, principalCVFromAddress } from "../common";
 import {
 	AnchorMode,
 	makeUnsignedSTXTokenTransfer,
@@ -35,7 +35,7 @@ export default class SendStx extends RyderCommand {
 		}
 		const stacksNetwork = networkFromString(network);
 		const options: UnsignedTokenTransferOptions = {
-			recipient,
+			recipient: principalCVFromAddress(recipient),
 			amount,
 			anchorMode: AnchorMode.OnChainOnly,
 			network: stacksNetwork,

--- a/src/commands/send-stx.ts
+++ b/src/commands/send-stx.ts
@@ -33,6 +33,8 @@ export default class SendStx extends RyderCommand {
 		if (!this.ryder_serial || !recipient) {
 			return;
 		}
+		if (account < 0 || account > 255)
+			throw new Error('account should be within 0-255');
 		const stacksNetwork = networkFromString(network);
 		const options: UnsignedTokenTransferOptions = {
 			recipient: principalCVFromAddress(recipient),
@@ -49,7 +51,10 @@ export default class SendStx extends RyderCommand {
 			options.fee = fee;
 		const transaction = await makeUnsignedSTXTokenTransfer(options);
 
-		const response = await this.ryder_serial.send(50); //FIXME use RyderSerial constant
+		const command = new Uint8Array(2);
+		command[0] = 50; //FIXME use RyderSerial constant
+		command[1] = account;
+		const response = await this.ryder_serial.send(command);
 		if (response === RyderSerial.RESPONSE_SEND_INPUT) {
 			const tx_bytes = transaction.serialize();
 			console.log('tx length', tx_bytes.byteLength);

--- a/src/commands/send-stx.ts
+++ b/src/commands/send-stx.ts
@@ -1,0 +1,78 @@
+import { flags } from "@oclif/command";
+import RyderSerial from "ryderserial-proto";
+import RyderCommand from "../base";
+import { principalFlag, networkFlag, networkFromString } from "../common";
+import {
+	AnchorMode,
+	makeUnsignedSTXTokenTransfer,
+	deserializeTransaction,
+	PostConditionMode,
+	broadcastTransaction,
+	UnsignedTokenTransferOptions
+} from "@stacks/transactions";
+
+export default class SendStx extends RyderCommand {
+	static description = "Send STX to a specified principal.";
+
+	static flags = {
+		...RyderCommand.flags,
+		help: flags.help({ char: "h" }),
+		amount: flags.integer({ description: "The amount in mSTX", required: true }),
+		nonce: flags.integer({ description: "The account nonce", required: false }),
+		fee: flags.integer({ description: "The fee in mSTX", required: false }),
+		memo: flags.string({ description: "Memo", required: false }),
+		account: flags.integer({ description: "The account number to send from", required: true }),
+		recipient: principalFlag({ description: "The principal to transfer the STX to", required: true }),
+		broadcast: flags.enum({ description: "Broadcast the transaction to the network", required: true, options: ["yes", "no"] }),
+		network: networkFlag()
+	};
+
+	async run() {
+		const { flags } = this.parse(SendStx);
+		const { amount, account, recipient, network, nonce, fee, memo, broadcast } = flags;
+		if (!this.ryder_serial || !recipient) {
+			return;
+		}
+		const stacksNetwork = networkFromString(network);
+		const options: UnsignedTokenTransferOptions = {
+			recipient,
+			amount,
+			anchorMode: AnchorMode.OnChainOnly,
+			network: stacksNetwork,
+			nonce: nonce || 0,
+			postConditionMode: PostConditionMode.Allow,
+			publicKey: ''
+		};
+		if (memo)
+			options.memo = memo;
+		if (fee)
+			options.fee = fee;
+		const transaction = await makeUnsignedSTXTokenTransfer(options);
+
+		const response = await this.ryder_serial.send(50); //FIXME use RyderSerial constant
+		if (response === RyderSerial.RESPONSE_SEND_INPUT) {
+			const tx_bytes = transaction.serialize();
+			console.log('tx length', tx_bytes.byteLength);
+			const tx_length = Buffer.from([tx_bytes.byteLength >> 24 & 0xff, tx_bytes.byteLength >> 16 & 0xff, tx_bytes.byteLength >> 8 & 0xff, tx_bytes.byteLength & 0xff]);
+			const data = Buffer.concat([tx_length, tx_bytes]);
+			const uint8a = new Uint8Array(data.byteLength);
+			for (let i = 0; i < data.byteLength; ++i)
+				uint8a[i] = data[i];
+			const signed: any = await this.ryder_serial.send(uint8a); //TODO use Uint8Array to get around a ryderserial-proto issue.
+			if (signed === RyderSerial.RESPONSE_REJECTED) {
+				console.log("User cancel");
+			}
+			else {
+				const signed_hex = Buffer.from(signed, 'binary').toString('hex');
+				if (broadcast === 'yes') {
+					const signedTransaction = deserializeTransaction(signed_hex);
+					const txid = await broadcastTransaction(signedTransaction, stacksNetwork);
+					console.log(txid);
+				}
+				else
+					console.log(signed_hex);
+			}
+		}
+		this.ryder_serial.close();
+	}
+}

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,0 +1,26 @@
+import { flags } from "@oclif/command";
+import { IOptionFlag } from "@oclif/command/lib/flags";
+import { validateStacksAddress } from "@stacks/transactions";
+import { StacksNetwork, StacksMainnet, StacksTestnet, StacksMocknet } from "@stacks/network";
+
+export function principalFlag(options: Partial<IOptionFlag<string>>) {
+	return flags.string({
+		...options,
+		parse: (input: string, context: any) => {
+			if (!validateStacksAddress(input))
+				throw new Error(`${input} is not a valid principal.`);
+			return options.parse ? options.parse(input, context) : input;
+		}
+	});
+}
+
+export const networkFlag = () => flags.enum({ required: true, options: ["mainnet", "testnet", "mocknet"] });
+
+export function networkFromString(network: string): StacksNetwork { // "mainnet" | "testnet" | "mocknet"
+	switch (network) {
+		case "mainnet": return new StacksMainnet();
+		default:
+		case "testnet": return new StacksTestnet();
+		case "mocknet": return new StacksMocknet();
+	}
+}

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,17 +1,25 @@
 import { flags } from "@oclif/command";
 import { IOptionFlag } from "@oclif/command/lib/flags";
-import { validateStacksAddress } from "@stacks/transactions";
+import { contractPrincipalCV, standardPrincipalCV, validateStacksAddress } from "@stacks/transactions";
 import { StacksNetwork, StacksMainnet, StacksTestnet, StacksMocknet } from "@stacks/network";
 
 export function principalFlag(options: Partial<IOptionFlag<string>>) {
 	return flags.string({
 		...options,
 		parse: (input: string, context: any) => {
-			if (!validateStacksAddress(input))
+			const [address, contract] = input.split('.');
+			if (!validateStacksAddress(address))
 				throw new Error(`${input} is not a valid principal.`);
+			if (typeof contract !== 'undefined' && !/^[a-zA-Z]([a-zA-Z0-9]|[-_])*$/.test(contract))
+				throw new Error(`${input} has an invalid contract name`);
 			return options.parse ? options.parse(input, context) : input;
 		}
 	});
+}
+
+export const principalCVFromAddress = (address: string) => {
+	const index = address.indexOf('.');
+	return index === -1 ? standardPrincipalCV(address) : contractPrincipalCV(address.substring(0, index), address.substring(index + 1));
 }
 
 export const networkFlag = () => flags.enum({ required: true, options: ["mainnet", "testnet", "mocknet"] });


### PR DESCRIPTION
Adds the `send-stx` command. It allows the user to send STX to an address. An unsigned transaction is created by the CLI and then sent to the Ryder via signing request.

```
Send STX to a specified principal.

USAGE
  $ ryder-cli-proto send-stx

OPTIONS
  -D, --debug
  -R, --ryder_port=ryder_port          (required) port of ryder device to connect to
  -h, --help                           show CLI help
  --account=account                    (required) The account number to send from
  --amount=amount                      (required) The amount in mSTX
  --broadcast=(yes|no)                 (required) Broadcast the transaction to the network
  --fee=fee                            The fee in mSTX
  --memo=memo                          Memo
  --network=(mainnet|testnet|mocknet)  (required)
  --nonce=nonce                        The account nonce
  --recipient=recipient                (required) The principal to transfer the STX to
```

Example:

```
send-stx -R /dev/ryder-device --amount 123 --account 0 --recipient SP.... --broadcast no --network mainnet
```